### PR TITLE
WIP: Ckuperst MBP 48 - Reduce admin load

### DIFF
--- a/common/tekton/configmaps/environment.yaml
+++ b/common/tekton/configmaps/environment.yaml
@@ -6,28 +6,30 @@ data:
   # TODO: Avoid specifying the github and quay org in multiple places
   GIT_EMAIL: "rnoriega@redhat.com"
   GIT_USERNAME: "oglok"
-  GIT_DEV_REPO_URL: https://github.com/redhat-edge-computing/manuela-dev.git
-  GIT_OPS_REPO_TEST_URL: https://github.com/redhat-edge-computing/manuela-gitops.git
-  GIT_OPS_REPO_PROD_URL: https://github.com/redhat-edge-computing/manuela-gitops.git
-  IOT_CONSUMER_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-consumer
+  GIT_ORG: redhat-edge-computing
+  GIT_PROVIDER: https://github.com
+  GIT_DEV_REPO_URL: manuela-dev.git
+  GIT_OPS_REPO_TEST_URL: manuela-gitops.git
+  GIT_OPS_REPO_PROD_URL: manuela-gitops.git
+  IOT_CONSUMER_REMOTE_IMAGE: iot-consumer
   IOT_CONSUMER_YAML_PATH: images.(name==messaging).newTag
   IOT_CONSUMER_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_CONSUMER_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/messaging/kustomization.yaml
   IOT_CONSUMER_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
-  IOT_FRONTEND_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-frontend
+  IOT_FRONTEND_REMOTE_IMAGE: iot-frontend
   IOT_FRONTEND_YAML_PATH: images.(name==line-dashboard).newTag
   IOT_FRONTEND_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_FRONTEND_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
   IOT_FRONTEND_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
-  IOT_SWSENSOR_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-software-sensor
+  IOT_SWSENSOR_REMOTE_IMAGE: iot-software-sensor
   IOT_SWSENSOR_YAML_PATH: images.(name==machine-sensor).newTag
   IOT_SWSENSOR_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_SWSENSOR_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
   IOT_SWSENSOR_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
-  IOT_ANOMALY_REMOTE_IMAGE: quay.io/redhat-edge-computing/iot-anomaly-detection
+  IOT_ANOMALY_REMOTE_IMAGE: iot-anomaly-detection
   IOT_ANOMALY_YAML_PATH: images.(name==anomaly-detection).newTag
   IOT_ANOMALY_TEST_KUSTOMIZATION_PATH: config/instances/manuela-tst/kustomization.yaml
   IOT_ANOMALY_PROD_KUSTOMIZATION_PATH: config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml
   IOT_ANOMALY_PROD_IMAGESTREAM_PATH: config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
   IMAGE_PROVIDER: quay.io
-  IMAGE_ORG: YOUR_QUAY_ORG
+  IMAGE_ORG: redhat-edge-computing

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -42,7 +42,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: $(params.DEV_REVISION)
     - name: subdirectory
@@ -62,7 +62,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory

--- a/common/tekton/pipelines/build-images.yaml
+++ b/common/tekton/pipelines/build-images.yaml
@@ -14,7 +14,7 @@ spec:
     default: tekton/images/httpd-ionic
   - name: OUTPUT_IMAGE_PROVIDER_CONFIGMAPKEY
     type: string
-    default: quay.io
+    default: IMAGE_PROVIDER
   - name: OUTPUT_IMAGE_ORG_CONFIGMAPKEY
     type: string
     default: IMAGE_ORG

--- a/common/tekton/pipelines/build-images.yaml
+++ b/common/tekton/pipelines/build-images.yaml
@@ -35,7 +35,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: $(params.DEV_REVISION)
     - name: subdirectory

--- a/common/tekton/pipelines/build-images.yaml
+++ b/common/tekton/pipelines/build-images.yaml
@@ -14,10 +14,10 @@ spec:
     default: tekton/images/httpd-ionic
   - name: OUTPUT_IMAGE_PROVIDER_CONFIGMAPKEY
     type: string
-    default: IMAGE_PROVIDER
+    default: quay.io
   - name: OUTPUT_IMAGE_ORG_CONFIGMAPKEY
     type: string
-    default: IMAGE_ORG
+    default: redhat-edge-computing
   - name: OUTPUT_IMAGE_NAME_CONFIGMAPKEY
     type: string
     default: httpd-ionic

--- a/common/tekton/tasks/bumpversion.yaml
+++ b/common/tekton/tasks/bumpversion.yaml
@@ -47,7 +47,7 @@ spec:
       name: scratch  
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/manuela/bumpversiontask:latest # review: is this supposed to be a static remote image path?
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-anomaly-detection.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-anomaly-detection.yaml
@@ -22,7 +22,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: master
     - name: subdirectory
@@ -42,7 +42,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-anomaly-detection.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-anomaly-detection.yaml
@@ -102,7 +102,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_ANOMALY_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_ANOMALY_REMOTE_IMAGE)
 
   - name: push-dev-tag
     taskRef:

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-consumer.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-consumer.yaml
@@ -102,7 +102,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_CONSUMER_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_CONSUMER_REMOTE_IMAGE)
 
   - name: push-dev-tag
     taskRef:

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-consumer.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-consumer.yaml
@@ -22,7 +22,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: master
     - name: subdirectory
@@ -42,7 +42,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-frontend.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-frontend.yaml
@@ -22,7 +22,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: master
     - name: subdirectory
@@ -42,7 +42,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-frontend.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-frontend.yaml
@@ -104,7 +104,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_FRONTEND_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_FRONTEND_REMOTE_IMAGE)
 
   - name: push-dev-tag
     taskRef:

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-software-sensor.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-software-sensor.yaml
@@ -102,7 +102,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_SWSENSOR_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_SWSENSOR_REMOTE_IMAGE)
 
   - name: push-dev-tag
     taskRef:

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-software-sensor.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed-iot-software-sensor.yaml
@@ -22,7 +22,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: master
     - name: subdirectory
@@ -42,7 +42,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed.yaml
@@ -223,7 +223,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_FRONTEND_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_FRONTEND_REMOTE_IMAGE)
 
   - name: copy-image-to-remote-registry-iot-consumer
     taskRef:
@@ -241,7 +241,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_CONSUMER_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_CONSUMER_REMOTE_IMAGE)
 
   - name: copy-image-to-remote-registry-iot-anomaly
     taskRef:
@@ -259,7 +259,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_ANOMALY_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_ANOMALY_REMOTE_IMAGE)
 
   - name: copy-image-to-remote-registry-iot-software-sensor
     taskRef:
@@ -277,7 +277,7 @@ spec:
     - name: SOURCE_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
     - name: TARGET_IMAGE_CONFIGMAPKEY
-      value: IOT_SWSENSOR_REMOTE_IMAGE
+      value: $(IMAGE_PROVIDER)/$(IMAGE_ORG)/$(IOT_SWSENSOR_REMOTE_IMAGE)
 
   - name: modify-ops-test-iot-frontend
     taskRef:

--- a/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/tekton/pipelines/seed.yaml
@@ -22,7 +22,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_DEV_REPO_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_DEV_REPO_URL)
     - name: revision
       value: master
     - name: subdirectory
@@ -40,7 +40,7 @@ spec:
       workspace: config
     params:
     - name: url_configmapkey
-      value: GIT_OPS_REPO_TEST_URL
+      value: $(GIT_PROVIDER)/$(GIT_ORG)/$(GIT_OPS_REPO_TEST_URL)
     - name: revision
       value: master
     - name: subdirectory


### PR DESCRIPTION
https://issues.redhat.com/browse/MBP-48

Refactoring uses of longform remote image URLs and Git repo URLs. 

- Added GIT_ORG and GIT_PROVIDER as new ConfigMap values to support issue request
- Removed image provider and organization from IOT_*_REMOTE_IMAGE ConfigMap values
- Removed git provider and git organization from GIT_*_URL ConfigMap values

Replaced all previous uses of ConfigMap values with newly concatenated values, preserving current nomenclature to avoid in-task definitions that cast the values as parameters.