### PR TITLE
Fix version number and some trailing whitespace

### DIFF
--- a/manufacturing-edge-ai-ml/main/values.yaml
+++ b/manufacturing-edge-ai-ml/main/values.yaml
@@ -29,13 +29,13 @@ subscriptions:
   useCSV: "False"
   version:
     gitops:
-      channel: stable   
+      channel: stable
       csv: v1.2.0
       source: redhat-operators
-      syncPolicy: Automatic 
+      syncPolicy: Automatic
     pipelines:
       channel: stable
-      csv: v1.5.0
+      csv: v1.5.1
       source: redhat-operators
     acm:
       channel: release-2.3


### PR DESCRIPTION
It seems the problem with pipelines was requesting version 1.5.0 instead of 1.5.1.  Please also delete references to 1.5.0 in any private values files you may have.