### PR TITLE
Master -> main changes

### DIFF
--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -30,7 +30,7 @@ spec:
     default: ""
   - name: DEV_REVISION
     type: string
-    default: master
+    default: main
   tasks:
   - name: git-clone-dev
     taskRef:
@@ -64,7 +64,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -171,7 +171,7 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main
 
   - name: argocd-sync-application
     taskRef:

--- a/common/tekton/pipelines/build-images.yaml
+++ b/common/tekton/pipelines/build-images.yaml
@@ -23,7 +23,7 @@ spec:
     default: httpd-ionic
   - name: DEV_REVISION 
     type: string 
-    default: master
+    default: main
   tasks:
   - name: git-clone-dev
     taskRef:

--- a/common/tekton/pipelines/stage-production.yaml
+++ b/common/tekton/pipelines/stage-production.yaml
@@ -29,7 +29,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_PROD_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -133,4 +133,4 @@ spec:
     - name: GIT_BRANCH_HEAD
       value: staging-approval
     - name: GIT_BRANCH_BASE
-      value: master
+      value: main

--- a/common/tekton/tasks/git-checkout.yaml
+++ b/common/tekton/tasks/git-checkout.yaml
@@ -10,7 +10,7 @@ spec:
   - name: BRANCH
     description: branch to check out or to create
     type: string
-    default: master
+    default: main
   - name: subdirectory
     description: subdirectory inside the "gitrepos" workspace to clone the git repo into
     type: string

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -66,7 +66,7 @@ spec:
 
       /ko-app/git-init \
         -url "$(cat $(workspaces.config.path)/$(params.url_configmapkey))" \
-        -revision "$(params.revision)" \
+        #-revision "$(params.revision)" \
         -path "$CHECKOUT_DIR" \
         -sslVerify="$(params.sslVerify)" \
         -submodules="$(params.submodules)" \
@@ -82,7 +82,9 @@ spec:
 
       echo "Branch info: $(git branch -v)"
 
-      git branch --set-upstream-to=origin/$(params.revision) main
+      #git branch --set-upstream-to=origin/$(params.revision) main
+      git branch --set-upstream-to=origin/$(params.revision)
+
       EXIT_CODE="$?"
       if [ "$EXIT_CODE" != 0 ]
       then

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -63,10 +63,11 @@ spec:
       if [[ "$(params.deleteExisting)" == "true" ]] ; then
         cleandir
       fi
+      
+        #-revision "$(params.revision)" \
 
       /ko-app/git-init \
         -url "$(cat $(workspaces.config.path)/$(params.url_configmapkey))" \
-        #-revision "$(params.revision)" \
         -path "$CHECKOUT_DIR" \
         -sslVerify="$(params.sslVerify)" \
         -submodules="$(params.submodules)" \

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -80,6 +80,8 @@ spec:
         exit $EXIT_CODE
       fi
 
+      echo "Branch info: $(git branch -v)"
+
       git branch --set-upstream-to=origin/$(params.revision) main
       EXIT_CODE="$?"
       if [ "$EXIT_CODE" != 0 ]

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -15,7 +15,7 @@ spec:
   - name: revision
     description: git revision to checkout (branch, tag, sha, ref…)
     type: string
-    default: master
+    default: main
   - name: submodules
     description: defines if the resource should initialize and fetch the submodules
     type: string
@@ -80,7 +80,7 @@ spec:
         exit $EXIT_CODE
       fi
 
-      git branch --set-upstream-to=origin/$(params.revision) master
+      git branch --set-upstream-to=origin/$(params.revision) main
       EXIT_CODE="$?"
       if [ "$EXIT_CODE" != 0 ]
       then

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -80,10 +80,8 @@ spec:
         exit $EXIT_CODE
       fi
 
+      # Seems the go git client checks out master regardless.  This allows for 'main' or another branch to be used
       git checkout $(params.revision)
-      echo "Branch info: $(git branch -v)"
-
-      #git branch --set-upstream-to=origin/$(params.revision) main
       git branch --set-upstream-to=origin/$(params.revision)
 
       EXIT_CODE="$?"

--- a/common/tekton/tasks/git-clone-with-tags.yaml
+++ b/common/tekton/tasks/git-clone-with-tags.yaml
@@ -63,11 +63,10 @@ spec:
       if [[ "$(params.deleteExisting)" == "true" ]] ; then
         cleandir
       fi
-      
-        #-revision "$(params.revision)" \
 
       /ko-app/git-init \
         -url "$(cat $(workspaces.config.path)/$(params.url_configmapkey))" \
+        -revision "$(params.revision)" \
         -path "$CHECKOUT_DIR" \
         -sslVerify="$(params.sslVerify)" \
         -submodules="$(params.submodules)" \
@@ -81,6 +80,7 @@ spec:
         exit $EXIT_CODE
       fi
 
+      git checkout $(params.revision)
       echo "Branch info: $(git branch -v)"
 
       #git branch --set-upstream-to=origin/$(params.revision) main

--- a/common/tekton/tasks/github-add-pull-request.yaml
+++ b/common/tekton/tasks/github-add-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: GIT_BRANCH_BASE
     description: The branch to pull into
     type: string
-    default: master
+    default: main
   steps:
   - name: create-pull-request
     image: curlimages/curl

--- a/common/tekton/tasks/s2i.yaml
+++ b/common/tekton/tasks/s2i.yaml
@@ -57,6 +57,8 @@ spec:
   - name: prepare-env
     image: quay.io/openshift-pipeline/s2i
     script: |
+      echo preparing env...
+
       if [[ "$(params.BUILDER_IMAGE)" == *"jdk"* ]] || [[ "$(params.BUILDER_IMAGE)" == *"java"* ]]; then 
         echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > env-file
 
@@ -96,6 +98,7 @@ spec:
     # - --as-dockerfile
     # - /gen-source/Dockerfile.gen
     script: |
+      echo generate
       if [ -f /env-params/s2icommand ]; then
         source /env-params/s2icommand
       else
@@ -104,6 +107,7 @@ spec:
       if [[ -n "$(params.CHAINED_BUILD_DOCKERFILE)" ]]; then
         echo "$(params.CHAINED_BUILD_DOCKERFILE)" >>/gen-source/Dockerfile.gen
       fi
+      echo done generating
     resources: {}
     volumeMounts:
     - mountPath: /gen-source
@@ -114,11 +118,13 @@ spec:
   - name: build
     image: quay.io/buildah/stable:v1.11.0
     script: |
+      echo gen-source
       if [ -f /env-params/buildahcommand ]; then
         source /env-params/buildahcommand
       else 
         buildah bud --tls-verify=$(params.TLSVERIFY) --storage-driver=vfs -f /gen-source/Dockerfile.gen -t $(params.OUTPUT_IMAGE) .
       fi
+      echo done gen-source
     resources: {}
     securityContext:
       privileged: false # LRC Changed from true
@@ -133,9 +139,11 @@ spec:
   - name: push
     image: quay.io/buildah/stable:v1.11.0
     script: |
+      echo build
       echo --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       echo -n "$(params.OUTPUT_IMAGE):$(params.TAG)" >$(results.image.path)
+      echo build done
     resources: {}
     securityContext:
       privileged: false # LRC Changed from true

--- a/common/tekton/tasks/s2i.yaml
+++ b/common/tekton/tasks/s2i.yaml
@@ -57,8 +57,6 @@ spec:
   - name: prepare-env
     image: quay.io/openshift-pipeline/s2i
     script: |
-      echo preparing env...
-
       if [[ "$(params.BUILDER_IMAGE)" == *"jdk"* ]] || [[ "$(params.BUILDER_IMAGE)" == *"java"* ]]; then 
         echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > env-file
 
@@ -98,7 +96,6 @@ spec:
     # - --as-dockerfile
     # - /gen-source/Dockerfile.gen
     script: |
-      echo generate
       if [ -f /env-params/s2icommand ]; then
         source /env-params/s2icommand
       else
@@ -107,7 +104,6 @@ spec:
       if [[ -n "$(params.CHAINED_BUILD_DOCKERFILE)" ]]; then
         echo "$(params.CHAINED_BUILD_DOCKERFILE)" >>/gen-source/Dockerfile.gen
       fi
-      echo done generating
     resources: {}
     volumeMounts:
     - mountPath: /gen-source
@@ -118,13 +114,11 @@ spec:
   - name: build
     image: quay.io/buildah/stable:v1.11.0
     script: |
-      echo gen-source
       if [ -f /env-params/buildahcommand ]; then
         source /env-params/buildahcommand
       else 
         buildah bud --tls-verify=$(params.TLSVERIFY) --storage-driver=vfs -f /gen-source/Dockerfile.gen -t $(params.OUTPUT_IMAGE) .
       fi
-      echo done gen-source
     resources: {}
     securityContext:
       privileged: false # LRC Changed from true
@@ -139,11 +133,8 @@ spec:
   - name: push
     image: quay.io/buildah/stable:v1.11.0
     script: |
-      echo build
-      echo --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       echo -n "$(params.OUTPUT_IMAGE):$(params.TAG)" >$(results.image.path)
-      echo build done
     resources: {}
     securityContext:
       privileged: false # LRC Changed from true

--- a/common/tekton/tasks/s2i.yaml
+++ b/common/tekton/tasks/s2i.yaml
@@ -133,6 +133,7 @@ spec:
   - name: push
     image: quay.io/buildah/stable:v1.11.0
     script: |
+      echo --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) $(params.OUTPUT_IMAGE) docker://$(params.OUTPUT_IMAGE):$(params.TAG)
       echo -n "$(params.OUTPUT_IMAGE):$(params.TAG)" >$(results.image.path)
     resources: {}

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-anomaly-detection.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-anomaly-detection.yaml
@@ -24,7 +24,7 @@ spec:
     - name: url_configmapkey
       value: GIT_DEV_REPO_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: dev
     - name: deleteExisting
@@ -44,7 +44,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -186,4 +186,4 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-consumer.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-consumer.yaml
@@ -24,7 +24,7 @@ spec:
     - name: url_configmapkey
       value: GIT_DEV_REPO_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: dev
     - name: deleteExisting
@@ -44,7 +44,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -187,4 +187,4 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-frontend.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-frontend.yaml
@@ -24,7 +24,7 @@ spec:
     - name: url_configmapkey
       value: GIT_DEV_REPO_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: dev
     - name: deleteExisting
@@ -44,7 +44,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -189,4 +189,4 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-software-sensor.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-software-sensor.yaml
@@ -24,7 +24,7 @@ spec:
     - name: url_configmapkey
       value: GIT_DEV_REPO_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: dev
     - name: deleteExisting
@@ -44,7 +44,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-software-sensor.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed-iot-software-sensor.yaml
@@ -186,4 +186,4 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
@@ -24,7 +24,7 @@ spec:
     - name: url_configmapkey
       value: GIT_DEV_REPO_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: dev
     - name: deleteExisting
@@ -42,7 +42,7 @@ spec:
     - name: url_configmapkey
       value: GIT_OPS_REPO_TEST_URL
     - name: revision
-      value: master
+      value: main
     - name: subdirectory
       value: ops
     - name: deleteExisting
@@ -469,4 +469,4 @@ spec:
     - name: subdirectory
       value: ops
     - name: PUSH_FLAGS
-      value: --set-upstream origin master
+      value: --set-upstream origin main


### PR DESCRIPTION
Also remove some trailing whitespace.

Includes a workaround for git-init checking out the master branch in a new clone - the script tasks in the git checkout jobs explicitly call git and set the branches that way now; no change needed to git-init.  (Maybe that behavior will change in a future release of git-init, but the workaround should continue to work when and if that changes.)

This bring blueprints and manuela-dev into sync with respect to master/main defaults