### PR TITLE
Restore kustomization.yaml in manuela-tst-all directory

### DIFF
--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -5,7 +5,7 @@ bases: []
 images:
 - name: messaging
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
-  newTag: 0.3.2-73
+  newTag: 0.3.2-74
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
   newTag: 0.3.1-42

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: 0.3.1-40
 - name: line-dashboard
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
-  newTag: 0.3.1-64
+  newTag: 0.3.1-65
 - name: anomaly-detection
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
   newTag: 0.3.2-43

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -8,7 +8,7 @@ images:
   newTag: 0.3.2-71
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
-  newTag: 0.3.1-40
+  newTag: 0.3.1-41
 - name: line-dashboard
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
   newTag: 0.3.1-65

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -14,4 +14,4 @@ images:
   newTag: 0.3.1-64
 - name: anomaly-detection
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
-  newTag: 0.3.2-42
+  newTag: 0.3.2-43

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -5,7 +5,7 @@ bases: []
 images:
 - name: messaging
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
-  newTag: 0.3.2-74
+  newTag: 0.3.2-75
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
   newTag: 0.3.1-42

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -5,7 +5,7 @@ bases: []
 images:
 - name: messaging
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
-  newTag: 0.3.2-71
+  newTag: 0.3.2-72
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
   newTag: 0.3.1-41

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: manuela-tst-all
+bases: []
+images:
+- name: messaging
+  newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+  newTag: 0.3.2-71
+- name: machine-sensor
+  newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
+  newTag: 0.3.1-40
+- name: line-dashboard
+  newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
+  newTag: 0.3.1-64
+- name: anomaly-detection
+  newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+  newTag: 0.3.2-42

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -5,7 +5,7 @@ bases: []
 images:
 - name: messaging
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
-  newTag: 0.3.2-75
+  newTag: 0.3.2-76
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
   newTag: 0.3.1-42

--- a/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/instances/manuela-tst/kustomization.yaml
@@ -5,13 +5,13 @@ bases: []
 images:
 - name: messaging
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
-  newTag: 0.3.2-72
+  newTag: 0.3.2-73
 - name: machine-sensor
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
-  newTag: 0.3.1-41
+  newTag: 0.3.1-42
 - name: line-dashboard
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
-  newTag: 0.3.1-65
+  newTag: 0.3.1-66
 - name: anomaly-detection
   newName: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
-  newTag: 0.3.2-43
+  newTag: 0.3.2-44

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: anomaly-detection
 spec:
   tags:
-  - name: 0.3.2-40
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-anomaly-detection:0.3.2-40
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-41
     from:
       kind: DockerImage
@@ -29,6 +22,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-anomaly-detection:0.3.2-43
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-44
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-anomaly-detection:0.3.2-44
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: anomaly-detection
 spec:
   tags:
-  - name: 0.3.2-39
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-anomaly-detection:0.3.2-39
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-40
     from:
       kind: DockerImage
@@ -36,6 +29,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-anomaly-detection:0.3.2-43
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-44
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-anomaly-detection:0.3.2-44
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: anomaly-detection
 spec:
   tags:
-  - name: 0.3.2-38
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-anomaly-detection:0.3.2-38
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-39
     from:
       kind: DockerImage
@@ -36,6 +29,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/claudiol/iot-anomaly-detection:0.3.2-42
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-43
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-anomaly-detection:0.3.2-43
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - anomaly-detection-is.yaml
 images:
 - name: anomaly-detection
-  newTag: 0.3.2-43
+  newTag: 0.3.2-44

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/anomaly-detection/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - anomaly-detection-is.yaml
 images:
 - name: anomaly-detection
-  newTag: 0.3.2-42
+  newTag: 0.3.2-43

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - line-dashboard-is.yaml
 images:
 - name: line-dashboard
-  newTag: 0.3.1-64
+  newTag: 0.3.1-65

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - line-dashboard-is.yaml
 images:
 - name: line-dashboard
-  newTag: 0.3.1-65
+  newTag: 0.3.1-66

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: line-dashboard
 spec:
   tags:
-  - name: 0.3.1-59
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-frontend:0.3.1-59
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-60
     from:
       kind: DockerImage
@@ -50,6 +43,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-frontend:0.3.1-65
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-66
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-frontend:0.3.1-66
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: line-dashboard
 spec:
   tags:
-  - name: 0.3.1-58
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-frontend:0.3.1-58
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-59
     from:
       kind: DockerImage
@@ -50,6 +43,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/claudiol/iot-frontend:0.3.1-64
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-65
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-frontend:0.3.1-65
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: line-dashboard
 spec:
   tags:
-  - name: 0.3.1-60
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-frontend:0.3.1-60
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-61
     from:
       kind: DockerImage
@@ -43,6 +36,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-frontend:0.3.1-65
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-66
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-frontend:0.3.1-66
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - machine-sensor-is.yaml
 images:
 - name: machine-sensor
-  newTag: 0.3.1-40
+  newTag: 0.3.1-41

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - machine-sensor-is.yaml
 images:
 - name: machine-sensor
-  newTag: 0.3.1-41
+  newTag: 0.3.1-42

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: machine-sensor
 spec:
   tags:
-  - name: 0.3.1-35
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-software-sensor:0.3.1-35
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-36
     from:
       kind: DockerImage
@@ -50,6 +43,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-software-sensor:0.3.1-41
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-42
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-software-sensor:0.3.1-42
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: machine-sensor
 spec:
   tags:
-  - name: 0.3.1-34
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-software-sensor:0.3.1-34
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-35
     from:
       kind: DockerImage
@@ -50,6 +43,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/claudiol/iot-software-sensor:0.3.1-40
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-41
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-software-sensor:0.3.1-41
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: machine-sensor
 spec:
   tags:
-  - name: 0.3.1-36
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-software-sensor:0.3.1-36
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.1-37
     from:
       kind: DockerImage
@@ -43,6 +36,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-software-sensor:0.3.1-41
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.1-42
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-software-sensor:0.3.1-42
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - messaging-is.yaml
 images:
 - name: messaging
-  newTag: 0.3.2-73
+  newTag: 0.3.2-74

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - messaging-is.yaml
 images:
 - name: messaging
-  newTag: 0.3.2-69
+  newTag: 0.3.2-72

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
 - messaging-is.yaml
 images:
 - name: messaging
-  newTag: 0.3.2-72
+  newTag: 0.3.2-73

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: messaging
 spec:
   tags:
-  - name: 0.3.2-65
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-consumer:0.3.2-65
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-67
     from:
       kind: DockerImage
@@ -36,6 +29,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-consumer:0.3.2-72
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-73
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-consumer:0.3.2-73
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: messaging
 spec:
   tags:
-  - name: 0.3.2-63
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-consumer:0.3.2-63
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-65
     from:
       kind: DockerImage
@@ -36,6 +29,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/claudiol/iot-consumer:0.3.2-69
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-72
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-consumer:0.3.2-72
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
+++ b/manufacturing-edge-ai-ml/gitops/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
@@ -4,13 +4,6 @@ metadata:
   name: messaging
 spec:
   tags:
-  - name: 0.3.2-67
-    from:
-      kind: DockerImage
-      name: quay.io/claudiol/iot-consumer:0.3.2-67
-    importPolicy: {}
-    referencePolicy:
-      type: Local
   - name: 0.3.2-68
     from:
       kind: DockerImage
@@ -36,6 +29,13 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/martjack/iot-consumer:0.3.2-73
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+  - name: 0.3.2-74
+    from:
+      kind: DockerImage
+      name: quay.io/martjack/iot-consumer:0.3.2-74
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
The existing yq workflow for bumping images requires this, and restoring it allows all of the pipelines to complete.