### PR TITLE
Change build-and-test pipeline to run all required builds

### DIFF
--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -84,6 +84,34 @@ spec:
     - name: version_file_path
       value: $(params.PATH_CONTEXT)/VERSION
 
+  - name: run-build-images
+    taskRef:
+      name: tkn
+    runAfter:
+    - bump-build-version
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-images
+      - --showlog
+      - --nocolour
+
+  - name: run-seed
+    taskRef:
+      name: tkn
+    runAfter:
+    - bump-build-version
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - seed
+      - --showlog
+      - --nocolour
+
   - name: s2i-build
     taskRef:
       name: s2i

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -106,7 +106,7 @@ spec:
     - name: github-secret
       workspace: github-secret
     - name: argocd-env-secret
-      workspace: argo-env-secret
+      workspace: argocd-env-secret
     - name: quay-secret
       workspace: quay-secret
 
@@ -133,7 +133,7 @@ spec:
     - name: build-artifacts
       workspace: build-artifacts
     - name: argocd-env-secret
-      workspace: argo-env-secret
+      workspace: argocd-env-secret
     - name: quay-secret
       workspace: quay-secret
 

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -43,6 +43,8 @@ spec:
       - start
       - build-images
       - --param
+      - PATH_CONTEXT=tekton/images/httpd-ionic
+      - --param
       - DEV_REVISION=($params.DEV_REVISION)
       - --param
       - OUTPUT_IMAGE_PROVIDER_CONFIGMAPKEY=IMAGE_PROVIDER

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -52,6 +52,7 @@ spec:
       - OUTPUT_IMAGE_ACCOUNT_CONFIGMAPKEY=IMAGE_ACCOUNT
       - --param
       - OUTPUT_IMAGE_NAME=httpd-ionic
+      - --workspace
       - name=gitrepos,claimName=build-images-rwo
       - --workspace
       - name=config,config=environment
@@ -59,7 +60,6 @@ spec:
       - name=github-secret,secret=github
       - --workspace
       - name=quay-secret,secret=quay-build-secret
-      - --workspace
       - --showlog
       - --nocolour
 

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -33,7 +33,33 @@ spec:
     type: string
     default: main
   tasks:
+  - name: seed
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - seed
+      - --workspace
+      - name=gitrepos,claimName=build-images-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=build-artifacts,claimName=build-artifacts-rwo
+      - --workspace
+      - name=argocd-env-secret,secret=argocd-env
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --showlog
+      - --nocolour
+
   - name: git-clone-dev
+    runAfter:
+      - seed
     taskRef:
       name: git-clone-with-tags
     workspaces:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -62,7 +62,8 @@ spec:
       - --nocolour
 
   - name: seed
-    runAfter: build-images
+    runAfter:
+      - build-images
     taskRef:
       name: tkn
     params:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -57,9 +57,30 @@ spec:
       - --showlog
       - --nocolour
 
+  - name: build-images
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-images
+      - name=gitrepos,claimName=build-images-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - --showlog
+      - --nocolour
+
   - name: git-clone-dev
     runAfter:
       - seed
+      - build-images
     taskRef:
       name: git-clone-with-tags
     workspaces:
@@ -110,58 +131,6 @@ spec:
       value: $(params.COMPONENT_NAME)
     - name: version_file_path
       value: $(params.PATH_CONTEXT)/VERSION
-
-#  - name: run-build-images
-#    taskRef:
-#      name: tkn
-#    runAfter:
-#    - s2i-build
-#    params:
-#    - name: ARGS
-#      value:
-#      - pipeline
-#      - start
-#      - build-images
-#      - --showlog
-#      - --nocolour
-#    workspaces:
-#    - name: gitrepos
-#      workspace: gitrepos
-#    - name: config
-#      workspace: config
-#    - name: github-secret
-#      workspace: github-secret
-#    - name: argocd-env-secret
-#      workspace: argocd-env-secret
-#    - name: quay-secret
-#      workspace: quay-secret
-
-#  - name: run-seed
-#    taskRef:
-#      name: tkn
-#    runAfter:
-#    - s2i-build
-#    params:
-#    - name: ARGS
-#      value:
-#      - pipeline
-#      - start
-#      - seed
-#      - --showlog
-#      - --nocolour
-#    workspaces:
-#    - name: gitrepos
-#      workspace: gitrepos
-#    - name: config
-#      workspace: config
-#    - name: github-secret
-#      workspace: github-secret
-#    - name: build-artifacts
-#      workspace: build-artifacts
-#    - name: argocd-env-secret
-#      workspace: argocd-env-secret
-#    - name: quay-secret
-#      workspace: quay-secret
 
   - name: s2i-build
     taskRef:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -9,6 +9,7 @@ spec:
   - name: github-secret
   - name: argocd-env-secret
   - name: build-artifacts
+  - name: quay-secret
   params:
   - name: S2I_BUILDER_IMAGE
     type: string
@@ -104,6 +105,8 @@ spec:
       workspace: config
     - name: github-secret
       workspace: github-secret
+    - name: argocd-env-secret
+      workspace: argo-env-secret
     - name: quay-secret
       workspace: quay-secret
 
@@ -127,10 +130,12 @@ spec:
       workspace: config
     - name: github-secret
       workspace: github-secret
-    - name: quay-secret
-      workspace: quay-secret
     - name: build-artifacts
       workspace: build-artifacts
+    - name: argocd-env-secret
+      workspace: argo-env-secret
+    - name: quay-secret
+      workspace: quay-secret
 
   - name: s2i-build
     taskRef:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -45,7 +45,7 @@ spec:
       - --param
       - PATH_CONTEXT=tekton/images/httpd-ionic
       - --param
-      - DEV_REVISION=($params.DEV_REVISION)
+      - DEV_REVISION=$(params.DEV_REVISION)
       - --param
       - OUTPUT_IMAGE_PROVIDER_CONFIGMAPKEY=IMAGE_PROVIDER
       - --param

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -88,7 +88,7 @@ spec:
     taskRef:
       name: tkn
     runAfter:
-    - bump-build-version
+    - s2ibuild
     params:
     - name: ARGS
       value:
@@ -97,12 +97,21 @@ spec:
       - build-images
       - --showlog
       - --nocolour
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    - name: github-secret
+      workspace: github-secret
+    - name: quay-secret
+      workspace: quay-secret
 
   - name: run-seed
     taskRef:
       name: tkn
     runAfter:
-    - bump-build-version
+    - s2ibuild
     params:
     - name: ARGS
       value:
@@ -111,6 +120,17 @@ spec:
       - seed
       - --showlog
       - --nocolour
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    - name: github-secret
+      workspace: github-secret
+    - name: quay-secret
+      workspace: quay-secret
+    - name: build-artifacts
+      workspace: build-artifacts
 
   - name: s2i-build
     taskRef:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -85,57 +85,57 @@ spec:
     - name: version_file_path
       value: $(params.PATH_CONTEXT)/VERSION
 
-  - name: run-build-images
-    taskRef:
-      name: tkn
-    runAfter:
-    - s2i-build
-    params:
-    - name: ARGS
-      value:
-      - pipeline
-      - start
-      - build-images
-      - --showlog
-      - --nocolour
-    workspaces:
-    - name: gitrepos
-      workspace: gitrepos
-    - name: config
-      workspace: config
-    - name: github-secret
-      workspace: github-secret
-    - name: argocd-env-secret
-      workspace: argocd-env-secret
-    - name: quay-secret
-      workspace: quay-secret
+#  - name: run-build-images
+#    taskRef:
+#      name: tkn
+#    runAfter:
+#    - s2i-build
+#    params:
+#    - name: ARGS
+#      value:
+#      - pipeline
+#      - start
+#      - build-images
+#      - --showlog
+#      - --nocolour
+#    workspaces:
+#    - name: gitrepos
+#      workspace: gitrepos
+#    - name: config
+#      workspace: config
+#    - name: github-secret
+#      workspace: github-secret
+#    - name: argocd-env-secret
+#      workspace: argocd-env-secret
+#    - name: quay-secret
+#      workspace: quay-secret
 
-  - name: run-seed
-    taskRef:
-      name: tkn
-    runAfter:
-    - s2i-build
-    params:
-    - name: ARGS
-      value:
-      - pipeline
-      - start
-      - seed
-      - --showlog
-      - --nocolour
-    workspaces:
-    - name: gitrepos
-      workspace: gitrepos
-    - name: config
-      workspace: config
-    - name: github-secret
-      workspace: github-secret
-    - name: build-artifacts
-      workspace: build-artifacts
-    - name: argocd-env-secret
-      workspace: argocd-env-secret
-    - name: quay-secret
-      workspace: quay-secret
+#  - name: run-seed
+#    taskRef:
+#      name: tkn
+#    runAfter:
+#    - s2i-build
+#    params:
+#    - name: ARGS
+#      value:
+#      - pipeline
+#      - start
+#      - seed
+#      - --showlog
+#      - --nocolour
+#    workspaces:
+#    - name: gitrepos
+#      workspace: gitrepos
+#    - name: config
+#      workspace: config
+#    - name: github-secret
+#      workspace: github-secret
+#    - name: build-artifacts
+#      workspace: build-artifacts
+#    - name: argocd-env-secret
+#      workspace: argocd-env-secret
+#    - name: quay-secret
+#      workspace: quay-secret
 
   - name: s2i-build
     taskRef:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -247,6 +247,8 @@ spec:
       value: --insecure
     - name: argocd-version
       value: "v1.5.2"
+    - name: revision
+      value: $(params.OPS_REVISION)
 
   # - name: sensor-broker-test
   #   taskRef:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -89,7 +89,6 @@ spec:
   - name: git-clone-dev
     runAfter:
       - seed
-      - build-images
     taskRef:
       name: git-clone-with-tags
     workspaces:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -88,7 +88,7 @@ spec:
     taskRef:
       name: tkn
     runAfter:
-    - s2ibuild
+    - s2i-build
     params:
     - name: ARGS
       value:
@@ -111,7 +111,7 @@ spec:
     taskRef:
       name: tkn
     runAfter:
-    - s2ibuild
+    - s2i-build
     params:
     - name: ARGS
       value:

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -33,7 +33,36 @@ spec:
     type: string
     default: main
   tasks:
+  - name: build-images
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-images
+      - --param
+      - DEV_REVISION=($params.DEV_REVISION)
+      - --param
+      - OUTPUT_IMAGE_PROVIDER_CONFIGMAPKEY=IMAGE_PROVIDER
+      - --param
+      - OUTPUT_IMAGE_ACCOUNT_CONFIGMAPKEY=IMAGE_ACCOUNT
+      - --param
+      - OUTPUT_IMAGE_NAME=httpd-ionic
+      - name=gitrepos,claimName=build-images-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - --showlog
+      - --nocolour
+
   - name: seed
+    runAfter: build-images
     taskRef:
       name: tkn
     params:
@@ -54,26 +83,6 @@ spec:
       - name=argocd-env-secret,secret=argocd-env
       - --workspace
       - name=quay-secret,secret=quay-build-secret
-      - --showlog
-      - --nocolour
-
-  - name: build-images
-    taskRef:
-      name: tkn
-    params:
-    - name: ARGS
-      value:
-      - pipeline
-      - start
-      - build-images
-      - name=gitrepos,claimName=build-images-rwo
-      - --workspace
-      - name=config,config=environment
-      - --workspace
-      - name=github-secret,secret=github
-      - --workspace
-      - name=quay-secret,secret=quay-build-secret
-      - --workspace
       - --showlog
       - --nocolour
 

--- a/common/tekton/pipelines/build-and-test.yaml
+++ b/common/tekton/pipelines/build-and-test.yaml
@@ -32,6 +32,9 @@ spec:
   - name: DEV_REVISION
     type: string
     default: main
+  - name: OPS_REVISION
+    type: string
+    default: main
   tasks:
   - name: build-images
     taskRef:

--- a/common/tekton/tasks/s2i.yaml
+++ b/common/tekton/tasks/s2i.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
-retries: 1
 metadata:
   name: s2i
 spec:

--- a/common/tekton/tasks/s2i.yaml
+++ b/common/tekton/tasks/s2i.yaml
@@ -1,5 +1,6 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
+retries: 1
 metadata:
   name: s2i
 spec:

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
@@ -109,6 +109,7 @@ spec:
       value: components/iot-software-sensor/VERSION
 
   - name: s2i-build-iot-frontend
+    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -131,6 +132,7 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
 
   - name: s2i-build-iot-consumer
+    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -151,6 +153,7 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
 
   - name: s2i-build-iot-anomaly
+    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -171,6 +174,7 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
 
   - name: s2i-build-iot-software-sensor
+    retries: 1
     taskRef:
       name: s2i
     workspaces:


### PR DESCRIPTION
build-and-test now invokes build-images and seed sequentially, so that build-and-test is now the only pipeline that needs to be explicitly triggered.  Parameters and workspaces are passed to the other pipelines as needed.