### PR TITLE
Make seed pipeline more resilient

### DIFF
--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
@@ -132,7 +132,7 @@ spec:
 
   - name: s2i-build-iot-consumer
     runAfter:
-      - s2i-build-iot-frontent
+      - s2i-build-iot-frontend
     taskRef:
       name: s2i
     workspaces:

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
@@ -131,6 +131,8 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
 
   - name: s2i-build-iot-consumer
+    runAfter:
+      - s2i-build-iot-frontent
     taskRef:
       name: s2i
     workspaces:
@@ -151,6 +153,8 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
 
   - name: s2i-build-iot-anomaly
+    runAfter:
+      - s2i-build-iot-consumer
     taskRef:
       name: s2i
     workspaces:
@@ -171,6 +175,8 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
 
   - name: s2i-build-iot-software-sensor
+    runAfter:
+      - s2i-build-iot-anomaly
     taskRef:
       name: s2i
     workspaces:

--- a/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
+++ b/manufacturing-edge-ai-ml/datacenter/pipelines/tekton/pipelines/seed.yaml
@@ -109,7 +109,6 @@ spec:
       value: components/iot-software-sensor/VERSION
 
   - name: s2i-build-iot-frontend
-    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -132,7 +131,6 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
 
   - name: s2i-build-iot-consumer
-    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -153,7 +151,6 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
 
   - name: s2i-build-iot-anomaly
-    retries: 1
     taskRef:
       name: s2i
     workspaces:
@@ -174,7 +171,6 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
 
   - name: s2i-build-iot-software-sensor
-    retries: 1
     taskRef:
       name: s2i
     workspaces:


### PR DESCRIPTION
seed now explicitly orders the s2i build to avoid the potential for contention between PVCs.

Previously, attempted to add the retries: element to the s2i tasks - but when this was enabled, the seed pipeline would not be recognized as complete, even when it successfully completed.  Even if retries: worked, it's not an elegant solution.